### PR TITLE
refactor: remove commit prompts and adjust handlers

### DIFF
--- a/lua/gp/config.lua
+++ b/lua/gp/config.lua
@@ -372,7 +372,6 @@ local config = {
 		.. "\n\nRespond exclusively with the snippet that should be prepended before the selection above.",
 	template_command = "{{command}}",
 
-	commit_prompt_template = require("gp.defaults").commit_prompt_template,
 	-- https://platform.openai.com/docs/guides/speech-to-text/quickstart
 	-- Whisper costs $0.006 / minute (rounded to the nearest second)
 	-- by eliminating silence and speeding up the tempo of the recording
@@ -539,7 +538,7 @@ local config = {
 		end,
 
 		-- GpInspectLog for checking the log file
-		InspectLog = function(plugin, params)
+		InspectLog = function(plugin)
 			local log_file = plugin.config.log_file
 			local buffer = plugin.helpers.get_buffer(log_file)
 			if not buffer then

--- a/lua/gp/defaults.lua
+++ b/lua/gp/defaults.lua
@@ -36,38 +36,4 @@ M.short_chat_template = [[
 {{user_prefix}}
 ]]
 
-M.commit_prompt_template = [[You are an expert at following the Conventional Commit specification. Given the git diff listed below, please generate a commit message for me:
-      1. First line: conventional commit format (type: concise description) (remember to use semantic types like feat, fix, docs, style, refactor, perf, test, chore, etc.)
-      2. Optional bullet points if more context helps:
-        - Keep the second line blank
-        - Keep them short and direct
-        - Focus on what changed
-        - Always be terse
-        - Don't overly explain
-        - Drop any fluffy or formal language
-
-      Return ONLY the commit message - no introduction, no explanation, no quotes around it.
-
-      Examples:
-      feat: add user auth system
-
-      - Add JWT tokens for API auth
-      - Handle token refresh for long sessions
-
-      fix: resolve memory leak in worker pool
-
-      - Clean up idle connections
-      - Add timeout for stale workers
-
-      Simple change example:
-      fix: typo in README.md
-
-      Very important: Do not respond with any of the examples. Your message must be based off the diff that is about to be provided, with a little bit of styling informed by the recent commits you're about to see.
-
-      Based on this format, generate appropriate commit messages. Respond with message only. DO NOT format the message in Markdown code blocks, DO NOT use backticks:
-
-      ```diff
-	  {{git_diff}}
-      ```
-      ]]
 return M


### PR DESCRIPTION
- Remove commit_prompt_template from config and defaults
- Simplify InspectLog signature by dropping unused params
- Fix prefixed line handling in dispatcher